### PR TITLE
Update demo_advanced.ipynb

### DIFF
--- a/examples/demo_advanced.ipynb
+++ b/examples/demo_advanced.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "!pip install llama-index\n",
-    "!pip install llama-index-core==0.10.6.post1\n",
+    "!pip install llama-index-core\n",
     "!pip install llama-index-embeddings-openai\n",
     "!pip install llama-index-postprocessor-flag-embedding-reranker\n",
     "!pip install git+https://github.com/FlagOpen/FlagEmbedding.git\n",


### PR DESCRIPTION
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. llama-index 0.10.9 requires llama-index-core<0.11.0,>=0.10.8.post1, but you have llama-index-core 0.10.6.post1 which is incompatible. llama-index-readers-llama-parse 0.1.2 requires llama-index-core<0.11.0,>=0.10.7, but you have llama-index-core 0.10.6.post1 which is incompatible. llama-parse 0.3.4 requires llama-index-core>=0.10.7, but you have llama-index-core 0.10.6.post1 which is incompatible.