### PR TITLE
Astra DB vector store imports from newly-named package

### DIFF
--- a/examples/demo_advanced_astradb.ipynb
+++ b/examples/demo_advanced_astradb.ipynb
@@ -23,8 +23,7 @@
     "!pip install llama-index-postprocessor-flag-embedding-reranker\n",
     "!pip install git+https://github.com/FlagOpen/FlagEmbedding.git\n",
     "!pip install llama-parse\n",
-    "!pip install llama-index-vector-stores-astra\n",
-    "!pip install astrapy"
+    "!pip install llama-index-vector-stores-astra"
    ]
   },
   {

--- a/examples/demo_advanced_astradb.ipynb
+++ b/examples/demo_advanced_astradb.ipynb
@@ -23,7 +23,7 @@
     "!pip install llama-index-postprocessor-flag-embedding-reranker\n",
     "!pip install git+https://github.com/FlagOpen/FlagEmbedding.git\n",
     "!pip install llama-parse\n",
-    "!pip install llama-index-vector-stores-astra"
+    "!pip install llama-index-vector-stores-astra-db"
    ]
   },
   {

--- a/examples/demo_advanced_astradb.ipynb
+++ b/examples/demo_advanced_astradb.ipynb
@@ -186,7 +186,7 @@
    },
    "outputs": [],
    "source": [
-    "from llama_index.vector_stores.astra import AstraDBVectorStore\n",
+    "from llama_index.vector_stores.astra_db import AstraDBVectorStore\n",
     "\n",
     "# define two storage classes representing two collections (to compare advanced approach vs. baseline) \n",
     "\n",

--- a/examples/demo_astradb.ipynb
+++ b/examples/demo_astradb.ipynb
@@ -166,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.vector_stores.astra import AstraDBVectorStore\n",
+    "from llama_index.vector_stores.astra_db import AstraDBVectorStore\n",
     "\n",
     "astra_db_store = AstraDBVectorStore(\n",
     "    token=token,\n",

--- a/examples/demo_astradb.ipynb
+++ b/examples/demo_astradb.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "# First, install the required dependencies\n",
-    "!pip install --quiet llama-index llama-parse llama-index-vector-stores-astra llama-index-llms-openai"
+    "!pip install --quiet llama-index llama-parse llama-index-vector-stores-astra-db llama-index-llms-openai"
    ]
   },
   {

--- a/examples/demo_astradb.ipynb
+++ b/examples/demo_astradb.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "# First, install the required dependencies\n",
-    "!pip install --quiet llama-index llama-parse llama-index-vector-stores-astra llama-index-llms-openai astrapy"
+    "!pip install --quiet llama-index llama-parse llama-index-vector-stores-astra llama-index-llms-openai"
    ]
   },
   {


### PR DESCRIPTION
**WARNING: Do not merge until [llama_index/#11056](https://github.com/run-llama/llama_index/pull/11056) is merged** (and the newly-named package published!)

This aligns the import statement for AstraDBVectorStore in the two example notebooks to reflect the package renaming that the PR referenced above implements.

It should be merged once the llama_index integration package is published as `llama-index-vector-stores-astra-db` on PyPI.