### PR TITLE
Astra DB notebooks allow optional namespace specification

### DIFF
--- a/examples/demo_advanced_astradb.ipynb
+++ b/examples/demo_advanced_astradb.ipynb
@@ -61,7 +61,8 @@
     "os.environ[\"OPENAI_API_KEY\"] = \"sk-\"\n",
     "\n",
     "ASTRA_API_ENDPOINT = \"<enter AstraDB endpoint>\"\n",
-    "ASTRA_TOKEN = \"<enter your Astra DB Token>\""
+    "ASTRA_TOKEN = \"<enter your Astra DB Token>\"\n",
+    "ASTRA_NAMESPACE = None  # or: \"my_keyspace\". Must exist on Astra already."
    ]
   },
   {
@@ -193,12 +194,14 @@
     "astra_db_store_advanced = AstraDBVectorStore(\n",
     "    token=ASTRA_TOKEN,\n",
     "    api_endpoint=ASTRA_API_ENDPOINT,\n",
+    "    namespace=ASTRA_NAMESPACE,\n",
     "    collection_name=\"astra_v_table_llamaparse_advanced\",\n",
     "    embedding_dimension=1536\n",
     ")\n",
     "astra_db_store_base = AstraDBVectorStore(\n",
     "    token=ASTRA_TOKEN,\n",
     "    api_endpoint=ASTRA_API_ENDPOINT,\n",
+    "    namespace=ASTRA_NAMESPACE,\n",
     "    collection_name=\"astra_v_table_llamaparse_base\",\n",
     "    embedding_dimension=1536\n",
     ")"

--- a/examples/demo_astradb.ipynb
+++ b/examples/demo_astradb.ipynb
@@ -51,8 +51,9 @@
     "\n",
     "# Get all required API keys and parameters\n",
     "llama_cloud_api_key = getpass(\"Enter your Llama Index Cloud API Key: \")\n",
-    "api_endpoint = input(\"Enter you Astra DB API Endpoint: \")\n",
+    "api_endpoint = input(\"Enter your Astra DB API Endpoint: \")\n",
     "token = getpass(\"Enter your Astra DB Token: \")\n",
+    "namespace = input(\"Enter your Astra DB namespace (optional, must exist on Astra): \") or None\n",
     "openai_api_key = getpass(\"Enter your OpenAI API Key: \")\n",
     "\n",
     "os.environ[\"LLAMA_CLOUD_API_KEY\"] = llama_cloud_api_key\n",
@@ -171,6 +172,7 @@
     "astra_db_store = AstraDBVectorStore(\n",
     "    token=token,\n",
     "    api_endpoint=api_endpoint,\n",
+    "    namespace=namespace,\n",
     "    collection_name=\"astra_v_table_llamaparse\",\n",
     "    embedding_dimension=1536\n",
     ")"


### PR DESCRIPTION
With this PR, the Astra DB notebooks have the option of specifying a namespace (if not specified, the default namespace is used).

This matches the new feature on the Astra UI to manage custom namespaces in one's database.

_(The notebooks remark that the namespace should exist already on DB when provisioning the vector stores.)_