### PR TITLE
fix(base): add file_path to exception msg

### DIFF
--- a/llama_parse/base.py
+++ b/llama_parse/base.py
@@ -219,7 +219,7 @@ class LlamaParse(BasePydanticReader):
                         )
                     ]
         except Exception as e:
-            print("Error while parsing the PDF file: ", e)
+            print(f"Error while parsing the PDF file '{file_path}':", e)
             return []
     
     async def aload_data(self, file_path: Union[List[str], str], extra_info: Optional[dict] = None) -> List[Document]:


### PR DESCRIPTION
Current PR adds `file_path` to the output; otherwise, it is not possible to see which file has failed. 
closes #52
