### PR TITLE
Logging file path when creating job

### DIFF
--- a/llama_parse/base.py
+++ b/llama_parse/base.py
@@ -288,7 +288,7 @@ class LlamaParse(BasePydanticReader):
         try:
             job_id = await self._create_job(file_path, extra_info=extra_info)
             if self.verbose:
-                print("Started parsing the file under job_id %s" % job_id)
+                print(f"Started parsing the file {file_path} under job_id {job_id}")
             
             result = await self._get_job_result(job_id, self.result_type.value)
 


### PR DESCRIPTION
I was processing a directory of files and it kept getting stuck on one file (I later discovered it was malformed). This file would never parse properly so it would take 30 minutes until the default timeout was passed and the process would move on. Because the logger only output the `job_id`, it took some trial an error until I discovered which file was causing the issue.

I added the file_path to the log statement when a job is kicked off. This way if a problematic file is encountered again while processing an entire directory, the user will have the exact file path as helpful context.

I also updated this log statement to use a f-string rather than legacy % interpolation.