### PR TITLE
Make Split to Page Default =  False

### DIFF
--- a/llama_parse/base.py
+++ b/llama_parse/base.py
@@ -110,7 +110,7 @@ class LlamaParse(BasePydanticReader):
         description="Whether or not to ignore and skip errors raised during parsing.",
     )
     split_by_page: bool = Field(
-        default=True,
+        default=False,
         description="Whether to split by page (NOTE: using a predefined separator `\n---\n`)",
     )
 


### PR DESCRIPTION
# Summary

I'm going to propose that we set the default to `False`. 

The current behavior (as of 0.4.4) is to load the entire text into the first element of the list ([link](https://github.com/run-llama/llama_parse/blob/v0.4.4/llama_parse/base.py#L205-L210)), and I'd like to make that the default.

* This would benefit us by making upgrading simpler. Our code that calls `load_data` expects to fetch the entire text using `result[0].text`. Upgrading would have surprised us by dropping pages. We'd have to spend time trackdown down the issue followed by adding `seperate_page=False`. 
* I cannot speak for other users, but we have documents whose parsed results contain `\n---\n`. This typically comes from a footer. Splitting on `---` can "introduce" pages.
