### PR TITLE
allow for bytes or buffer as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@ documents = await parser.aload_data("./my_file.pdf")
 documents = await parser.aload_data(["./my_file1.pdf", "./my_file2.pdf"])
 ```
 
+## Using with file object
+
+You can parse a file object directly:
+
+```python
+import nest_asyncio
+
+nest_asyncio.apply()
+
+from llama_parse import LlamaParse
+
+parser = LlamaParse(
+    api_key="llx-...",  # can also be set in your env as LLAMA_CLOUD_API_KEY
+    result_type="markdown",  # "markdown" and "text" are available
+    num_workers=4,  # if multiple files passed, split in `num_workers` API calls
+    verbose=True,
+    language="en",  # Optionally you can define a language, default=en
+)
+
+with open("./my_file1.pdf", "rb") as f:
+    documents = parser.load_data(f)
+
+# you can also pass file bytes directly
+with open("./my_file1.pdf", "rb") as f:
+    file_bytes = f.read()
+    documents = parser.load_data(file_bytes)
+```
+
 ## Using with `SimpleDirectoryReader`
 
 You can also integrate the parser as the default PDF loader in `SimpleDirectoryReader`:

--- a/llama_parse/base.py
+++ b/llama_parse/base.py
@@ -147,7 +147,9 @@ class LlamaParse(BasePydanticReader):
         return url or v or DEFAULT_BASE_URL
 
     # upload a document and get back a job_id
-    async def _create_job(self, file_input: FileInput, extra_info: Optional[dict] = None) -> str:
+    async def _create_job(
+        self, file_input: FileInput, extra_info: Optional[dict] = None
+    ) -> str:
         headers = {"Authorization": f"Bearer {self.api_key}"}
         url = f"{self.base_url}/api/parsing/upload"
         files = None
@@ -155,7 +157,9 @@ class LlamaParse(BasePydanticReader):
 
         if isinstance(file_input, (bytes, BufferedIOBase)):
             if not extra_info or "file_name" not in extra_info:
-                raise ValueError("file_name must be provided in extra_info when passing bytes")
+                raise ValueError(
+                    "file_name must be provided in extra_info when passing bytes"
+                )
             file_name = extra_info["file_name"]
             mime_type = mimetypes.guess_type(file_name)[0]
             files = {"file": (file_name, file_input, mime_type)}
@@ -163,14 +167,18 @@ class LlamaParse(BasePydanticReader):
             file_path = str(file_input)
             file_ext = os.path.splitext(file_path)[1]
             if file_ext not in SUPPORTED_FILE_TYPES:
-                raise Exception(f"Currently, only the following file types are supported: {SUPPORTED_FILE_TYPES}\n"
-                                f"Current file type: {file_ext}")
+                raise Exception(
+                    f"Currently, only the following file types are supported: {SUPPORTED_FILE_TYPES}\n"
+                    f"Current file type: {file_ext}"
+                )
             mime_type = mimetypes.guess_type(file_path)[0]
             # Open the file here for the duration of the async context
-            file_handle = open(file_path, 'rb')
+            file_handle = open(file_path, "rb")
             files = {"file": (os.path.basename(file_path), file_handle, mime_type)}
         else:
-            raise ValueError("file_input must be either a file path string, file bytes, or buffer object")
+            raise ValueError(
+                "file_input must be either a file path string, file bytes, or buffer object"
+            )
 
         try:
             async with httpx.AsyncClient(timeout=self.max_timeout) as client:
@@ -249,7 +257,10 @@ class LlamaParse(BasePydanticReader):
                     )
 
     async def _aload_data(
-        self, file_path: FileInput, extra_info: Optional[dict] = None, verbose: bool = False
+        self,
+        file_path: FileInput,
+        extra_info: Optional[dict] = None,
+        verbose: bool = False,
     ) -> List[Document]:
         """Load data from the input path."""
         try:
@@ -273,14 +284,16 @@ class LlamaParse(BasePydanticReader):
                 return docs
 
         except Exception as e:
-            print(f"Error while parsing the file '{file_path}':", e)
+            print(f"Error while parsing the file {file_path}:", e)
             if self.ignore_errors:
                 return []
             else:
                 raise e
 
     async def aload_data(
-        self, file_path: Union[List[FileInput], FileInput], extra_info: Optional[dict] = None
+        self,
+        file_path: Union[List[FileInput], FileInput],
+        extra_info: Optional[dict] = None,
     ) -> List[Document]:
         """Load data from the input path."""
         if isinstance(file_path, (str, Path, bytes, BufferedIOBase)):
@@ -317,7 +330,9 @@ class LlamaParse(BasePydanticReader):
             )
 
     def load_data(
-        self, file_path: Union[List[FileInput], FileInput], extra_info: Optional[dict] = None
+        self,
+        file_path: Union[List[FileInput], FileInput],
+        extra_info: Optional[dict] = None,
     ) -> List[Document]:
         """Load data from the input path."""
         try:
@@ -343,14 +358,16 @@ class LlamaParse(BasePydanticReader):
             return [result]
 
         except Exception as e:
-            print(f"Error while parsing the file '{file_path}':", e)
+            print(f"Error while parsing the file {file_path}:", e)
             if self.ignore_errors:
                 return []
             else:
                 raise e
 
     async def aget_json(
-        self, file_path: Union[List[FileInput], FileInput], extra_info: Optional[dict] = None
+        self,
+        file_path: Union[List[FileInput], FileInput],
+        extra_info: Optional[dict] = None,
     ) -> List[dict]:
         """Load data from the input path."""
         if isinstance(file_path, (str, Path)):
@@ -378,7 +395,9 @@ class LlamaParse(BasePydanticReader):
             )
 
     def get_json_result(
-        self, file_path: Union[List[FileInput], FileInput], extra_info: Optional[dict] = None
+        self,
+        file_path: Union[List[FileInput], FileInput],
+        extra_info: Optional[dict] = None,
     ) -> List[dict]:
         """Parse the input path."""
         try:

--- a/llama_parse/base.py
+++ b/llama_parse/base.py
@@ -284,7 +284,8 @@ class LlamaParse(BasePydanticReader):
                 return docs
 
         except Exception as e:
-            print(f"Error while parsing the file {file_path}:", e)
+            file_repr = file_path if isinstance(file_path, str) else "<bytes/buffer>"
+            print(f"Error while parsing the file '{file_repr}':", e)
             if self.ignore_errors:
                 return []
             else:
@@ -358,7 +359,8 @@ class LlamaParse(BasePydanticReader):
             return [result]
 
         except Exception as e:
-            print(f"Error while parsing the file {file_path}:", e)
+            file_repr = file_path if isinstance(file_path, str) else "<bytes/buffer>"
+            print(f"Error while parsing the file '{file_repr}':", e)
             if self.ignore_errors:
                 return []
             else:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -17,6 +17,7 @@ def test_simple_page_text() -> None:
     assert len(result) == 1
     assert len(result[0].text) > 0
 
+
 @pytest.fixture
 def markdown_parser() -> LlamaParse:
     if os.environ.get("LLAMA_CLOUD_API_KEY", "") == "":
@@ -32,6 +33,7 @@ def test_simple_page_markdown(markdown_parser: LlamaParse) -> None:
     assert len(result) == 1
     assert len(result[0].text) > 0
 
+
 def test_simple_page_markdown_bytes(markdown_parser: LlamaParse) -> None:
     markdown_parser = LlamaParse(result_type="markdown", ignore_errors=False)
 
@@ -43,9 +45,12 @@ def test_simple_page_markdown_bytes(markdown_parser: LlamaParse) -> None:
     # client must provide extra_info with file_name
     with pytest.raises(ValueError):
         result = markdown_parser.load_data(file_bytes)
-    result = markdown_parser.load_data(file_bytes, extra_info={"file_name": "attention_is_all_you_need.pdf"})
+    result = markdown_parser.load_data(
+        file_bytes, extra_info={"file_name": "attention_is_all_you_need.pdf"}
+    )
     assert len(result) == 1
     assert len(result[0].text) > 0
+
 
 def test_simple_page_markdown_buffer(markdown_parser: LlamaParse) -> None:
     markdown_parser = LlamaParse(result_type="markdown", ignore_errors=False)
@@ -57,7 +62,9 @@ def test_simple_page_markdown_buffer(markdown_parser: LlamaParse) -> None:
         # client must provide extra_info with file_name
         with pytest.raises(ValueError):
             result = markdown_parser.load_data(f)
-        result = markdown_parser.load_data(f, extra_info={"file_name": "attention_is_all_you_need.pdf"})
+        result = markdown_parser.load_data(
+            f, extra_info={"file_name": "attention_is_all_you_need.pdf"}
+        )
         assert len(result) == 1
         assert len(result[0].text) > 0
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -17,20 +17,49 @@ def test_simple_page_text() -> None:
     assert len(result) == 1
     assert len(result[0].text) > 0
 
+@pytest.fixture
+def markdown_parser() -> LlamaParse:
+    if os.environ.get("LLAMA_CLOUD_API_KEY", "") == "":
+        pytest.skip("LLAMA_CLOUD_API_KEY not set")
+    return LlamaParse(result_type="markdown", ignore_errors=False)
 
-@pytest.mark.skipif(
-    os.environ.get("LLAMA_CLOUD_API_KEY", "") == "",
-    reason="LLAMA_CLOUD_API_KEY not set",
-)
-def test_simple_page_markdown() -> None:
-    parser = LlamaParse(result_type="markdown")
+
+def test_simple_page_markdown(markdown_parser: LlamaParse) -> None:
+    filepath = os.path.join(
+        os.path.dirname(__file__), "test_files/attention_is_all_you_need.pdf"
+    )
+    result = markdown_parser.load_data(filepath)
+    assert len(result) == 1
+    assert len(result[0].text) > 0
+
+def test_simple_page_markdown_bytes(markdown_parser: LlamaParse) -> None:
+    markdown_parser = LlamaParse(result_type="markdown", ignore_errors=False)
 
     filepath = os.path.join(
         os.path.dirname(__file__), "test_files/attention_is_all_you_need.pdf"
     )
-    result = parser.load_data(filepath)
+    with open(filepath, "rb") as f:
+        file_bytes = f.read()
+    # client must provide extra_info with file_name
+    with pytest.raises(ValueError):
+        result = markdown_parser.load_data(file_bytes)
+    result = markdown_parser.load_data(file_bytes, extra_info={"file_name": "attention_is_all_you_need.pdf"})
     assert len(result) == 1
     assert len(result[0].text) > 0
+
+def test_simple_page_markdown_buffer(markdown_parser: LlamaParse) -> None:
+    markdown_parser = LlamaParse(result_type="markdown", ignore_errors=False)
+
+    filepath = os.path.join(
+        os.path.dirname(__file__), "test_files/attention_is_all_you_need.pdf"
+    )
+    with open(filepath, "rb") as f:
+        # client must provide extra_info with file_name
+        with pytest.raises(ValueError):
+            result = markdown_parser.load_data(f)
+        result = markdown_parser.load_data(f, extra_info={"file_name": "attention_is_all_you_need.pdf"})
+        assert len(result) == 1
+        assert len(result[0].text) > 0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
allows for clients to pass in the file as `bytes` or a buffer of bytes. Added tests to cover both `bytes` and buffer input cases.