### PR TITLE
fix file_input type issue

### DIFF
--- a/llama_parse/base.py
+++ b/llama_parse/base.py
@@ -163,7 +163,7 @@ class LlamaParse(BasePydanticReader):
             file_name = extra_info["file_name"]
             mime_type = mimetypes.guess_type(file_name)[0]
             files = {"file": (file_name, file_input, mime_type)}
-        elif isinstance(file_input, str):
+        elif isinstance(file_input, (str, Path)):
             file_path = str(file_input)
             file_ext = os.path.splitext(file_path)[1]
             if file_ext not in SUPPORTED_FILE_TYPES:


### PR DESCRIPTION
Using LlamaParse with SimpleDirectoryReader having error with the file_input type (I got the error in this PR: https://github.com/run-llama/create-llama/pull/154, also this error: https://github.com/run-llama/llama_parse/issues/268). 
```
Error while parsing the file '<bytes/buffer>': file_input must be either a file path string, file bytes, or buffer object
Traceback (most recent call last):
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_index/core/readers/file/base.py", line 538, in load_file
    docs = reader.load_data(input_file, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 343, in load_data
    return asyncio.run(self.aload_data(file_path, extra_info))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/nest_asyncio.py", line 30, in run
    return loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/nest_asyncio.py", line 98, in run_until_complete
    return f.result()
           ^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/futures.py", line 203, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/tasks.py", line 267, in __step
    result = coro.send(None)
             ^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 304, in aload_data
    return await self._aload_data(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 295, in _aload_data
    raise e
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 270, in _aload_data
    job_id = await self._create_job(file_path, extra_info=extra_info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 182, in _create_job
    raise ValueError(
ValueError: file_input must be either a file path string, file bytes, or buffer object
```

I think using the simple example script in the README.md can help you reproduce the issue:
```python
parser = LlamaParse(
    api_key="llx-...",  # can also be set in your env as LLAMA_CLOUD_API_KEY
    result_type="markdown",  # "markdown" and "text" are available
    verbose=True,
)

file_extractor = {".pdf": parser}
documents = SimpleDirectoryReader(
    "./data", file_extractor=file_extractor
).load_data()
```

I guess dues to a change in SimpleDirectoryReader that the input_type for the file_extractor now become a Path type instead of a raw string: https://github.com/run-llama/llama_parse/blob/8b96176d8a3246f66480a1e6d26af1e68f5a29d6/llama_parse/base.py#L166
Adding the Path type can easily fix the issue so i made a PR for this. 

Please help me to have a look. 
Thank you!