### PR TITLE
Make File Extension Check Case-Insensitive

### DIFF
--- a/llama_parse/base.py
+++ b/llama_parse/base.py
@@ -165,7 +165,7 @@ class LlamaParse(BasePydanticReader):
             files = {"file": (file_name, file_input, mime_type)}
         elif isinstance(file_input, (str, Path)):
             file_path = str(file_input)
-            file_ext = os.path.splitext(file_path)[1]
+            file_ext = os.path.splitext(file_path)[1].lower()
             if file_ext not in SUPPORTED_FILE_TYPES:
                 raise Exception(
                     f"Currently, only the following file types are supported: {SUPPORTED_FILE_TYPES}\n"


### PR DESCRIPTION
# Summary

This PR makes  extension check case-insensitive. We've noticed that parsing fails for files with capitalized extension like `.PDF`. This will permit users to parse files such as `*.PDF` without having to change the extension to `*.pdf`.

I confirmed that no elements in `SUPPORTED_FILE_TYPES` have uppercase letters.

# Tested
Attempted to parse file `test.PDF`. I received an error 
```
Exception: Currently, only the following file types are supported: ['.pdf', '.602', '.abw', '.cgm', '.cwk', '.doc', '.docx', '.docm', '.dot', '.dotm', '.hwp', '.key', '.lwp', '.mw', '.mcw', '.pages', '.pbd', '.ppt', '.pptm', '.pptx', '.pot', '.potm', '.potx', '.rtf', '.sda', '.sdd', '.sdp', '.sdw', '.sgl', '.sti', '.sxi', '.sxw', '.stw', '.sxg', '.txt', '.uof', '.uop', '.uot', '.vor', '.wpd', '.wps', '.xml', '.zabw', '.epub', '.jpg', '.jpeg', '.png', '.gif', '.bmp', '.svg', '.tiff', '.webp', '.htm', '.html', '.xlsx', '.xls', '.xlsm', '.xlsb', '.xlw', '.csv', '.dif', '.sylk', '.slk', '.prn', '.numbers', '.et', '.ods', '.fods', '.uos1', '.uos2', '.dbf', '.wk1', '.wk2', '.wk3', '.wk4', '.wks', '.123', '.wq1', '.wq2', '.wb1', '.wb2', '.wb3', '.qpw', '.xlr', '.eth', '.tsv']
Current file type: .PDF
```
After making the change I can successfully parse the file. 

