### PR TITLE
Remove JSON from valid result types

### DIFF
--- a/llama_parse/utils.py
+++ b/llama_parse/utils.py
@@ -10,7 +10,6 @@ class ResultType(str, Enum):
 
     TXT = "text"
     MD = "markdown"
-    JSON = "json"
 
 
 class Language(str, Enum):


### PR DESCRIPTION
Make this invalid (as it should be):
```py
parser = LlamaParse(result_type="json")
documents = parser.load_data(pdf_file_name)
```

The way of getting the json is:
```py
parser.get_json_result(path)
```